### PR TITLE
Mention the DCO `Signed-off-by` requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,27 @@
 Violating any of the below may result in a source submission
 being rejected.
 
+## Developer Certificate of Origin
+
+The project maintainers for DANOS will only accept contributions using the
+[Developer’s Certificate of Origin 1.1][6] (“DCO”). The DCO is a legally binding
+statement asserting that you are the creator of your contribution, or that you
+otherwise have the authority to distribute the contribution, and that you are
+intentionally making the contribution available under the license associated
+with the given repository.
+
+You can agree to the DCO in your contribution by using a “Signed-off-by” line
+at the end of your commit message. You should only submit a contribution if you
+are willing to agree to the DCO terms. If you are willing, just add a line to
+the end of every git commit message:
+
+```Signed-off-by: Jane Smith <jane.smith@email.com>```
+
+You may type this line on your own when writing your commit messages. However,
+Git makes it easy to add this line to your commit messages. If you set your
+`user.name` and `user.email` as part of your git configuration, you can sign
+your commit automatically with `git commit -s`.
+
 ## Use Protobuf format messages
 
 The dataplane has three general configuration message formats:
@@ -74,3 +95,4 @@ You **must not** introduce any new warnings.
 [3]: http://cppcheck.sourceforge.net/ "Cppcheck Static Analyser"
 [4]: http://cpputest.github.io/ "Cpputest Unit Test Framework"
 [5]: http://libcheck.github.io/check/ "Check Unit Test Framework"
+[6]: https://developercertificate.org "Developer Certificate of Origin"


### PR DESCRIPTION
Add a section to CONTRIBUTING.md about the Developer Certificate of
Origin and the git signed-off-by requirement.