### PR TITLE
ndpi *.cfg files should be in /config/ directory

### DIFF
--- a/src/npf/dpi/ndpi.c
+++ b/src/npf/dpi/ndpi.c
@@ -37,8 +37,8 @@
 #include "util.h"
 #include "vplane_debug.h"
 
-#define NDPI_PROTOCOLS_PATH	"/opt/vyatta/etc/dpi/protocols.cfg"
-#define NDPI_CATEGORIES_PATH	"/opt/vyatta/etc/dpi/categories.cfg"
+#define NDPI_PROTOCOLS_PATH	"/config/ndpi/protocols.cfg"
+#define NDPI_CATEGORIES_PATH	"/config/ndpi/categories.cfg"
 
 #define NDPI_FLOW_PKT_MAX 10
 


### PR DESCRIPTION
Jira ticket [DAN-411](https://danosproject.atlassian.net/browse/DAN-411)

Currently ndpi.c loads nDPI .cfg files from /opt/vyatta/ directory. 

#define NDPI_PROTOCOLS_PATH	"/opt/vyatta/etc/dpi/protocols.cfg"
#define NDPI_CATEGORIES_PATH	"/opt/vyatta/etc/dpi/categories.cfg"

/opt/vyatta/* directory is overwritten on software upgrade.
It is suggested that configuration file path is changed to /config/ndpi/